### PR TITLE
Add prerequisite of nvidia-container-toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@ This package is still in under active-development. [Here](https://github.com/Hir
 
 
 ## Howto use
+#### Prerequisite
+`nvidia-container-toolkit` is required.
+```
+distribution=$(. /etc/os-release;echo $ID$VERSION_ID) \
+   && curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add - \
+   && curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
+sudo apt update
+sudo apt install -y nvidia-container-toolkit
+sudo systemctl restart docker
+```
 #### Building docker image
 ```bash
 git clone https://github.com/HiroIshida/detic_ros.git


### PR DESCRIPTION
This PR updates README.
To run docker container on gpu, nvidia-container-toolkit is required.