### PR TITLE
Add support for real-time models

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,6 @@ ENV ROS_DISTRO noetic
 # install ros packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-noetic-ros-core=1.5.0-1* \
-    ros-noetic-jsk-recognition-msgs \
     && rm -rf /var/lib/apt/lists/*
 
 # # install launch/sample_detection.launch dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ ENV ROS_DISTRO noetic
 # install ros packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-noetic-ros-core=1.5.0-1* \
+    ros-noetic-jsk-recognition-msgs \
     && rm -rf /var/lib/apt/lists/*
 
 # install bootstrap tools

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-noetic-jsk-recognition-msgs \
     && rm -rf /var/lib/apt/lists/*
 
+# # install launch/sample_detection.launch dependencies
+# RUN apt-get install -y --no-install-recommends \
+#     ros-noetic-jsk-pcl-ros \
+#     ros-noetic-jsk-pcl-ros-utils \
+#     && rm -rf /var/lib/apt/lists/*
+
 # install bootstrap tools
 RUN apt-get update && apt-get install --no-install-recommends -y \
     build-essential \

--- a/README.md
+++ b/README.md
@@ -48,10 +48,16 @@ Example for using the published topic from the node above is [masked_image_publi
   - Input image
 - `~debug_image` (`sensor_msgs/Image`)
   - debug image 
-- `~debug_segmentation_image` (`sensor_msgs/Image` with `8UC1` encoding)
+- `~debug_segmentation_image` (`sensor_msgs/Image` with `32SC1` encoding)
   - Say detected class number is 14, `~segmentation_image` in grayscale image is almost completely dark and not good for debugging. Therefore this topic scale the value to [0 ~ 255] so that grayscale image is human-friendly.
 - `~segmentation_info` (`detic_ros/SegmentationInfo`)
-  - class name list, confidence score list and segmentation image with `8UC1` encoding. The image is filled by 0 and positive integers indicating segmented object number. These indexes correspond to those of class name list and confidence score list. Note that index 0 is always reserved for 'background' instance and the confidence of the that instance is always 1.0.
+  - Published when `use_jsk_msgs` is false. Includes the class name list, confidence score list and segmentation image with `32SC1` encoding. The image is filled by 0 and positive integers indicating segmented object number. These indexes correspond to one plus those of class name list and confidence score list. For example, an image value of 2 corresponds to the second (index=1) item in the class name and score list. Note that the image value of 0 is always reserved for the 'background' instance.
+- `~segmentation` (`sensor_msgs/Image`)
+  - Published when `use_jsk_msgs` is true. Includes the segmentation image with `32SC1` encoding.
+- `~detected_classes` (`jsk_recognition_msgs/LabelArray`)
+  - Published when `use_jsk_msgs` is true. Includes the names and ids of the detected objects. In the same order as `~score`.
+- `~score` (`jsk_recognition_msgs/VectorArray`)
+  - Published when `use_jsk_msgs` is true. Includes the confidence score of the detected objects. In the same order as `~detected_classes`.
 
 As for rosparam, see [node_cofig.py](./node_script/node_config.py).
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,15 @@ ROS package for [Detic](https://github.com/facebookresearch/Detic). Run on both 
 
 ![image](https://drive.google.com/uc?export=view&id=1aiWK51VL9pQvEKABpodRG7CkJRcjZodw)
 
-example of customize vocabulary. Left: default (lvis), Right: custom ('bottle,shoe')
+example of custom vocabulary. Left: default (lvis), Right: custom ('bottle,shoe')
 
 <img src='https://user-images.githubusercontent.com/67531577/161755658-7a0eeff2-0559-4320-a438-0904a0e3c515.png' width=25%> <img src='https://user-images.githubusercontent.com/67531577/161755524-b39ae38b-797a-4a57-9288-a569403c5909.png' width=25%>
 
-## How to running as a node
+example of three dimensional pose recognition for cups, bottles, and bottle caps.
+
+<img src='https://user-images.githubusercontent.com/20625381/199499891-c5b66103-0de1-4619-ad64-0d1571efba92.png' width=50%>
+
+## Running as a node
 
 ### step1 (build docker container and launch Detic-segmentor node)
 *Ofcourse you can build this pacakge on your workspace and launch as normal ros package. But for those using CUDA, the following docker based approach might be safer and easy.*
@@ -37,8 +41,30 @@ docker run --rm --net=host -it --gpus 1 detic_ros:latest \
     input_image:=/kinect_head/rgb/image_color'
 ```
 Change the `pr1040` part and `/kinect_head/rgb/image_color` in command above by your custom host name and an image topic. If compressed image (e.g. `/kinect_head/rgb/image_color/compressed`) corresponding to the specified `input_image` is also published, by setting `compressed:=true`, you can reduce the topic pub-sub latency. device is set to `auto` by default. But you can specify either from `cpu` or `cuda`.
+
+Example for running three dimensional object pose detection on pr1040 (**you will need to install additional dependencies**, see comments in [Dockerfile](https://github.com/HiroIshida/detic_ros/blob/master/Dockerfile) for more details):
+```bash
+docker run --rm --net=host -it --gpus 1 detic_ros:latest \
+    /bin/bash -i -c \
+    'source ~/.bashrc; \
+    rossetip; rossetmaster pr1040; \
+    roslaunch detic_ros sample_detection.launch \
+    debug:=true \
+    vocabulary:=custom \
+    custom_vocabulary:=bottle,cup \
+```
+
 ### custom vocabulary
 Add additional arguments to the script above. example: `vocabulary:='custom' custom_vocabulary:='bottle,shoe'`. 
+
+### model types
+Detic is trained in different model types. In this repository you can try out all of the [real-time models](https://github.com/facebookresearch/Detic/blob/main/docs/MODEL_ZOO.md#real-time-models) using the `model_type` parameter.
+
+### running with higher frequency
+
+For higher recognition frequencies turn off all debug info, run on GPU, decompress topics locally, use smaller models (*e.g.* `res50`), and avoid having too many classes in the frame (by *e.g.* setting a custom vocabulary or higher confidence thresholds).
+
+The `sample_detection.launch` with default parameters handles all of this, yielding object bounding boxes at around 10Hz.
 
 ### step2 (Subscribe from node in step1 and do something)
 Example for using the published topic from the node above is [masked_image_publisher.py](./example/masked_image_publisher.py). This will be helpful for understanding how to apply `SegmentationInfo` message to a image. The [test file](/test/test_node.test) for this example also might be helpful.

--- a/launch/decompress_depth.launch
+++ b/launch/decompress_depth.launch
@@ -1,0 +1,20 @@
+<launch>
+
+  <arg name="input_image"/>
+  <arg name="input_depth"/>
+
+  <node name="image_decompresser"
+       pkg="image_transport" type="republish"
+       args="compressed raw" respawn="true">
+    <remap from="in" to="/$(arg input_image)"/>
+    <remap from="out" to="decompressed_image"/>
+  </node>
+
+  <node name="depth_decompresser"
+       pkg="image_transport" type="republish"
+       args="compressedDepth raw" respawn="true">
+    <remap from="in" to="/$(arg input_depth)"/>
+    <remap from="out" to="decompressed_depth"/>
+  </node>
+
+</launch>

--- a/launch/decompress_depth.launch
+++ b/launch/decompress_depth.launch
@@ -10,6 +10,7 @@
     <remap from="out" to="decompressed_image"/>
   </node>
 
+  <!-- needs image_transport_plugins/#64 -->
   <node name="depth_decompresser"
        pkg="image_transport" type="republish"
        args="compressedDepth raw" respawn="true">

--- a/launch/sample.launch
+++ b/launch/sample.launch
@@ -2,6 +2,7 @@
   <arg name="namespace" default="docker" />
 
   <arg name="verbose" default="true" />
+  <arg name="model_type" default="swin" />
   <arg name="enable_pubsub" default="true" />
   <arg name="out_debug_img" default="true" />
   <arg name="out_debug_segimg" default="true" />
@@ -27,6 +28,7 @@
           output="screen" >
     <remap from="~input_image" to="$(arg _input_image)"/>
     <param name="verbose" value="$(arg verbose)"/>
+    <param name="model_type" value="$(arg model_type)" />
     <param name="enable_pubsub" value="$(arg enable_pubsub)"/>
     <param name="out_debug_img" value="$(arg out_debug_img)"/>
     <param name="out_debug_segimg" value="$(arg out_debug_segimg)"/>

--- a/launch/sample.launch
+++ b/launch/sample.launch
@@ -4,7 +4,7 @@
   <arg name="verbose" default="true" />
   <arg name="enable_pubsub" default="true" />
   <arg name="out_debug_img" default="true" />
-  <arg name="out_debug_segimage" default="true" />
+  <arg name="out_debug_segimg" default="true" />
   <arg name="confidence_threshold" default="0.5" />
   <arg name="input_image" default="input" />
   <arg name="compressed" default="true" />
@@ -29,7 +29,7 @@
     <param name="verbose" value="$(arg verbose)"/>
     <param name="enable_pubsub" value="$(arg enable_pubsub)"/>
     <param name="out_debug_img" value="$(arg out_debug_img)"/>
-    <param name="out_debug_segimage" value="$(arg out_debug_segimage)"/>
+    <param name="out_debug_segimg" value="$(arg out_debug_segimg)"/>
     <param name="confidence_threshold" value="$(arg confidence_threshold)"/>
     <param name="device" value="$(arg device)"/>
     <param name="vocabulary" value="$(arg vocabulary)" />

--- a/launch/sample_detection.launch
+++ b/launch/sample_detection.launch
@@ -52,6 +52,7 @@
       <remap from="~output" to="detic_segmentor/indices"/>
     </node>
 
+    <!-- cluster_filter: 1 may be unstable? jsk_recognition/#2737 -->
     <node name="detic_euclidean_clustering"
           pkg="nodelet" type="nodelet"
           args="load jsk_pcl/EuclideanClustering $(arg MANAGER)"

--- a/launch/sample_detection.launch
+++ b/launch/sample_detection.launch
@@ -60,7 +60,12 @@
       <remap from="~input/cluster_indices" to="detic_segmentor/indices"/>
       <rosparam>
         multi: true
+        tolerance: 0.03
+        min_size: 10
         downsample_enable: true
+        cluster_filter: 1
+        approximate_sync: true
+        queue_size: 100
       </rosparam>
     </node>
 
@@ -76,7 +81,10 @@
         align_boxes: true
         align_boxes_with_plane: false
         force_to_flip_z_axis: false
+        use_pca: false
         target_frame_id: base_footprint
+        approximate_sync: true
+        queue_size: 100
       </rosparam>
     </node>
 

--- a/launch/sample_detection.launch
+++ b/launch/sample_detection.launch
@@ -52,15 +52,27 @@
       <remap from="~output" to="detic_segmentor/indices"/>
     </node>
 
+    <node name="detic_euclidean_clustering"
+          pkg="nodelet" type="nodelet"
+          args="load jsk_pcl/EuclideanClustering $(arg MANAGER)"
+          clear_params="true">
+      <remap from="~input" to="depth_registered/points"/>
+      <remap from="~input/cluster_indices" to="detic_segmentor/indices"/>
+      <rosparam>
+        multi: true
+        downsample_enable: true
+      </rosparam>
+    </node>
+
     <node name="detic_cluster_point_indices_decomposer"
           pkg="nodelet" type="nodelet"
           args="load jsk_pcl/ClusterPointIndicesDecomposer $(arg MANAGER)"
           clear_params="true">
       <remap from="~input" to="depth_registered/points"/>
-      <remap from="~target" to="detic_segmentor/indices"/>
+      <remap from="~target" to="detic_euclidean_clustering/output"/>
       <remap from="~boxes" to="detic_segmentor/output/boxes"/>
       <remap from="~centroid_pose_array" to="detic_segmentor/output/centroid"/>
-      <rosparam subst_value="true">
+      <rosparam>
         align_boxes: true
         align_boxes_with_plane: false
         force_to_flip_z_axis: false

--- a/launch/sample_detection.launch
+++ b/launch/sample_detection.launch
@@ -1,0 +1,66 @@
+<launch>
+
+  <arg name="MANAGER" value="detic_detection_manager"/>
+
+  <arg name="namespace" default="docker" />
+
+  <arg name="input_image" default="/kinect_head/rgb/image_rect_color"/>
+  <arg name="input_cloud" default="/kinect_head/depth_registered/points"/>
+  <arg name="model_type" default="res50"/>
+  <arg name="compressed" default="true"/>
+  <arg name="vocabulary" default="lvis"/>
+  <arg name="custom_vocabulary" default=""/>
+  <arg name="confidence_threshold" default="0.5"/>
+  <arg name="debug" default="false"/>
+
+  <arg name="_input_image" default="/$(arg namespace)/decompressed_image" if="$(arg compressed)"/>
+  <arg name="_input_image" default="$(arg input_image)" unless="$(arg compressed)"/>
+
+  <group ns='$(arg namespace)'>
+
+    <node name="$(arg MANAGER)" pkg="nodelet" type="nodelet" args="manager"/>
+
+    <include file="$(find detic_ros)/launch/decompress.launch" if="$(arg compressed)">
+      <arg name="in" value="$(arg input_image)"/>
+    </include>
+
+    <node name="detic_segmentor" pkg="detic_ros" type="node.py" output="screen">
+      <remap from="~input_image" to="$(arg _input_image)"/>
+      <param name="enable_pubsub" value="true"/>
+      <param name="use_jsk_msgs" value="true"/>
+      <param name="verbose" value="$(arg debug)"/>
+      <param name="out_debug_img" value="$(arg debug)"/>
+      <param name="out_debug_segimg" value="$(arg debug)"/>
+      <param name="model_type" value="$(arg model_type)"/>
+      <param name="compressed" value="$(arg compressed)"/>
+      <param name="vocabulary" value="$(arg vocabulary)"/>
+      <param name="custom_vocabulary" value="$(arg custom_vocabulary)"/>
+      <param name="confidence_threshold" value="$(arg confidence_threshold)"/>
+    </node>
+
+    <node name="detic_label_image_to_indices"
+          pkg="nodelet" type="nodelet"
+          args="load jsk_pcl_utils/LabelToClusterPointIndices $(arg MANAGER)">
+      <remap from="~input" to="detic_segmentor/segmentation"/>
+      <remap from="~output" to="detic_segmentor/indices"/>
+    </node>
+
+    <node name="detic_cluster_point_indices_decomposer"
+          pkg="nodelet" type="nodelet"
+          args="load jsk_pcl/ClusterPointIndicesDecomposer $(arg MANAGER)"
+          clear_params="true">
+      <remap from="~input" to="$(arg input_cloud)"/>
+      <remap from="~target" to="detic_segmentor/indices"/>
+      <remap from="~boxes" to="detic_segmentor/output/boxes"/>
+      <remap from="~centroid_pose_array" to="detic_segmentor/output/centroid"/>
+      <rosparam subst_value="true">
+        align_boxes: true
+        align_boxes_with_plane: false
+        force_to_flip_z_axis: false
+        target_frame_id: base_footprint
+      </rosparam>
+    </node>
+
+  </group>
+
+</launch>

--- a/launch/sample_detection.launch
+++ b/launch/sample_detection.launch
@@ -5,26 +5,34 @@
   <arg name="namespace" default="docker" />
 
   <arg name="input_image" default="/kinect_head/rgb/image_rect_color"/>
-  <arg name="input_cloud" default="/kinect_head/depth_registered/points"/>
+  <arg name="input_depth" default="/kinect_head/depth_registered/image"/>
+  <arg name="input_camera_info" default="/kinect_head/depth_registered/camera_info"/>
   <arg name="model_type" default="res50"/>
-  <arg name="compressed" default="true"/>
   <arg name="vocabulary" default="lvis"/>
   <arg name="custom_vocabulary" default=""/>
   <arg name="confidence_threshold" default="0.5"/>
   <arg name="debug" default="false"/>
 
-  <arg name="_input_image" default="/$(arg namespace)/decompressed_image" if="$(arg compressed)"/>
-  <arg name="_input_image" default="$(arg input_image)" unless="$(arg compressed)"/>
+  <arg name="_input_image" default="/$(arg namespace)/decompressed_image"/>
+  <arg name="_input_depth" default="/$(arg namespace)/decompressed_depth"/>
 
   <group ns='$(arg namespace)'>
 
     <node name="$(arg MANAGER)" pkg="nodelet" type="nodelet" args="manager"/>
 
-    <include file="$(find detic_ros)/launch/decompress.launch" if="$(arg compressed)">
-      <arg name="in" value="$(arg input_image)"/>
+    <include file="$(find detic_ros)/launch/decompress_depth.launch">
+      <arg name="input_image" value="$(arg input_image)"/>
+      <arg name="input_depth" value="$(arg input_depth)"/>
     </include>
 
-    <node name="detic_segmentor" pkg="detic_ros" type="node.py" output="screen">
+    <node pkg="nodelet" type="nodelet" name="decompress_points"
+          args="load depth_image_proc/point_cloud_xyzrgb $(arg MANAGER)">
+      <remap from="rgb/camera_info" to="$(arg input_camera_info)"/>
+      <remap from="rgb/image_rect_color" to="$(arg _input_image)"/>
+      <remap from="depth_registered/image_rect" to="$(arg _input_depth)"/>
+    </node>
+
+  <node name="detic_segmentor" pkg="detic_ros" type="node.py" output="screen">
       <remap from="~input_image" to="$(arg _input_image)"/>
       <param name="enable_pubsub" value="true"/>
       <param name="use_jsk_msgs" value="true"/>
@@ -32,7 +40,6 @@
       <param name="out_debug_img" value="$(arg debug)"/>
       <param name="out_debug_segimg" value="$(arg debug)"/>
       <param name="model_type" value="$(arg model_type)"/>
-      <param name="compressed" value="$(arg compressed)"/>
       <param name="vocabulary" value="$(arg vocabulary)"/>
       <param name="custom_vocabulary" value="$(arg custom_vocabulary)"/>
       <param name="confidence_threshold" value="$(arg confidence_threshold)"/>
@@ -49,7 +56,7 @@
           pkg="nodelet" type="nodelet"
           args="load jsk_pcl/ClusterPointIndicesDecomposer $(arg MANAGER)"
           clear_params="true">
-      <remap from="~input" to="$(arg input_cloud)"/>
+      <remap from="~input" to="depth_registered/points"/>
       <remap from="~target" to="detic_segmentor/indices"/>
       <remap from="~boxes" to="detic_segmentor/output/boxes"/>
       <remap from="~centroid_pose_array" to="detic_segmentor/output/centroid"/>

--- a/node_script/batch_processor.py
+++ b/node_script/batch_processor.py
@@ -116,7 +116,8 @@ if __name__=='__main__':
     assert len(image_list) > 0
     print('{} images found'.format(len(image_list)))
 
-    node_config = NodeConfig.from_args(model_type, True, False, False, False,
+    node_config = NodeConfig.from_args(model_type,
+                                       False, True, False, False, False,
                                        confidence_threshold, device)
     detic_wrapper = DeticWrapper(node_config)
     results = [detic_wrapper.infer(image) for image in tqdm.tqdm(image_list)]
@@ -129,7 +130,7 @@ if __name__=='__main__':
     # dump debug gif image
     bridge = CvBridge()
     convert = lambda msg: bridge.imgmsg_to_cv2(msg, desired_encoding='passthrough')
-    debug_iamges = [result[1] for result in results]
-    images = list(map(convert, debug_iamges))
+    debug_images = [result[1] for result in results]
+    images = list(map(convert, debug_images))
     clip = ImageSequenceClip(images, fps=20)
     clip.write_gif(debug_file_name, fps=20)

--- a/node_script/batch_processor.py
+++ b/node_script/batch_processor.py
@@ -81,6 +81,7 @@ def dump_result_as_rosbag(input_bagfile_name, results, output_file_name):
 if __name__=='__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('input', type=str, help='input file path')
+    parser.add_argument('-model', type=str, default='swin', help='model type')
     parser.add_argument('-topic', type=str, default='', help='topic name')
     parser.add_argument('-n', type=int, default=-1, help='number of image to be processed')
     parser.add_argument('-out', type=str, default='', help='out file path')
@@ -90,6 +91,7 @@ if __name__=='__main__':
 
     args = parser.parse_args()
     input_file_path = args.input
+    model_type = args.model
     topic_name = args.topic
     output_file_name = args.out
     output_format = args.format
@@ -114,7 +116,8 @@ if __name__=='__main__':
     assert len(image_list) > 0
     print('{} images found'.format(len(image_list)))
 
-    node_config = NodeConfig.from_args(True, False, False, confidence_threshold, device)
+    node_config = NodeConfig.from_args(model_type, True, False, False,
+                                       confidence_threshold, device)
     detic_wrapper = DeticWrapper(node_config)
     results = [detic_wrapper.infer(image) for image in tqdm.tqdm(image_list)]
 

--- a/node_script/batch_processor.py
+++ b/node_script/batch_processor.py
@@ -116,7 +116,7 @@ if __name__=='__main__':
     assert len(image_list) > 0
     print('{} images found'.format(len(image_list)))
 
-    node_config = NodeConfig.from_args(model_type, True, False, False,
+    node_config = NodeConfig.from_args(model_type, True, False, False, False,
                                        confidence_threshold, device)
     detic_wrapper = DeticWrapper(node_config)
     results = [detic_wrapper.infer(image) for image in tqdm.tqdm(image_list)]

--- a/node_script/node.py
+++ b/node_script/node.py
@@ -18,6 +18,9 @@ class DeticRosNode:
     pub_debug_image: Publisher
     pub_debug_segmentation_image: Publisher
     pub_info: Publisher
+    pub_segimg: Publisher
+    pub_labels: Publisher
+    pub_score: Publisher
 
     def __init__(self, node_config: Optional[NodeConfig]=None):
         if node_config is None:

--- a/node_script/node.py
+++ b/node_script/node.py
@@ -60,14 +60,14 @@ class DeticRosNode:
             self.pub_labels.publish(self.detic_wrapper.get_label_array(labels))
             self.pub_score.publish(self.detic_wrapper.get_score_array(scores))
         else:
-            seg_info = self.detic_wrapper.get_segmentation_info(labels, scores)
+            seg_info = self.detic_wrapper.get_segmentation_info(seg_img, labels, scores)
             self.pub_info.publish(seg_info)
 
         # Publish optional topics
         if self.pub_debug_image is not None and vis_img is not None:
             debug_img = self.detic_wrapper.get_debug_img(vis_img)
             self.pub_debug_image.publish(debug_img)
-        if self.pub_debug_segmentation_image is not None and debug_seg_img is not None:
+        if self.pub_debug_segmentation_image is not None:
             debug_seg_img = self.detic_wrapper.get_debug_segimg()
             self.pub_debug_segmentation_image.publish(debug_seg_img)
 

--- a/node_script/node.py
+++ b/node_script/node.py
@@ -36,7 +36,7 @@ class DeticRosNode:
                 self.pub_debug_image = rospy.Publisher('~debug_image', Image, queue_size=1)
             else:
                 self.pub_debug_image = None
-            if node_config.out_debug_segimage:
+            if node_config.out_debug_segimg:
                 self.pub_debug_segmentation_image = rospy.Publisher('~debug_segmentation_image',
                                                                     Image, queue_size=10)
             else:

--- a/node_script/node.py
+++ b/node_script/node.py
@@ -52,7 +52,7 @@ class DeticRosNode:
 
     def callback_image(self, msg: Image):
         # Inference
-        seg_img, labels, scores, vis_img = self.detic_wrapper.infer(msg)
+        seg_img, labels, scores, vis_img = self.detic_wrapper.inference_step(msg)
 
         # Publish main topics
         if self.detic_wrapper.node_config.use_jsk_msgs:

--- a/node_script/node.py
+++ b/node_script/node.py
@@ -6,6 +6,7 @@ from rospy import Subscriber, Publisher
 from sensor_msgs.msg import Image
 from detic_ros.msg import SegmentationInfo
 from detic_ros.srv import DeticSeg, DeticSegRequest, DeticSegResponse
+from jsk_recognition_msgs.msg import LabelArray, VectorArray
 
 from node_config import NodeConfig
 from wrapper import DeticWrapper
@@ -23,14 +24,19 @@ class DeticRosNode:
             node_config = NodeConfig.from_rosparam()
 
         self.detic_wrapper = DeticWrapper(node_config)
-
         self.srv_handler = rospy.Service('~segment_image', DeticSeg, self.callback_srv)
 
         if node_config.enable_pubsub:
             # As for large buff_size please see:
             # https://answers.ros.org/question/220502/image-subscriber-lag-despite-queue-1/?answer=220505?answer=220505#post-id-22050://answers.ros.org/question/220502/image-subscriber-lag-despite-queue-1/?answer=220505?answer=220505#post-id-220505
             self.sub = rospy.Subscriber('~input_image', Image, self.callback_image, queue_size=1, buff_size=2**24)
-            self.pub_info = rospy.Publisher('~segmentation_info', SegmentationInfo, queue_size=1)
+            if node_config.use_jsk_msgs:
+                self.pub_segimg = rospy.Publisher('~segmentation', Image, queue_size=1)
+                self.pub_labels = rospy.Publisher('~detected_classes', LabelArray, queue_size=1)
+                self.pub_score = rospy.Publisher('~score', VectorArray, queue_size=1)
+            else:
+                self.pub_info = rospy.Publisher('~segmentation_info', SegmentationInfo,
+                                                queue_size=1)
 
             if node_config.out_debug_img:
                 self.pub_debug_image = rospy.Publisher('~debug_image', Image, queue_size=1)
@@ -45,12 +51,30 @@ class DeticRosNode:
         rospy.loginfo('initialized node')
 
     def callback_image(self, msg: Image):
-        seginfo, debug_img, debug_seg_img = self.detic_wrapper.infer(msg)
-        self.pub_info.publish(seginfo)
-        if self.pub_debug_image is not None and debug_img is not None:
+        # Inference
+        seg_img, labels, scores, vis_img = self.detic_wrapper.infer(msg)
+
+        # Publish main topics
+        if self.detic_wrapper.node_config.use_jsk_msgs:
+            self.pub_segimg.publish(seg_img)
+            self.pub_labels.publish(self.detic_wrapper.get_label_array(labels))
+            self.pub_score.publish(self.detic_wrapper.get_score_array(scores))
+        else:
+            seg_info = self.detic_wrapper.get_segmentation_info(labels, scores)
+            self.pub_info.publish(seg_info)
+
+        # Publish optional topics
+        if self.pub_debug_image is not None and vis_img is not None:
+            debug_img = self.detic_wrapper.get_debug_img(vis_img)
             self.pub_debug_image.publish(debug_img)
         if self.pub_debug_segmentation_image is not None and debug_seg_img is not None:
+            debug_seg_img = self.detic_wrapper.get_debug_segimg()
             self.pub_debug_segmentation_image.publish(debug_seg_img)
+
+        # Print debug info
+        if self.detic_wrapper.node_config.verbose:
+            time_elapsed_total = (rospy.Time.now() - msg.header.stamp).to_sec()
+            rospy.loginfo('total elapsed time in callback {}'.format(time_elapsed_total))
 
     def callback_srv(self, req: DeticSegRequest) -> DeticSegResponse:
         msg = req.image

--- a/node_script/node_config.py
+++ b/node_script/node_config.py
@@ -13,9 +13,6 @@ from detectron2.config import get_cfg
 from centernet.config import add_centernet_config
 from detic.config import add_detic_config
 
-# model_name = 'Detic_LCOCOI21k_CLIP_SwinB_896b32_4x_ft4x_max-size'
-model_name = 'Detic_LCOCOI21k_CLIP_CXT21k_640b32_4x_ft4x_max-size'
-# model_name = 'Detic_LCOCOI21k_CLIP_R18_640b32_4x_ft4x_max-size'
 
 @dataclass
 class NodeConfig:
@@ -30,8 +27,16 @@ class NodeConfig:
     confidence_threshold: float
     device_name: str
 
+    model_names = {
+        'swin': 'Detic_LCOCOI21k_CLIP_SwinB_896b32_4x_ft4x_max-size',
+        'convnet': 'Detic_LCOCOI21k_CLIP_CXT21k_640b32_4x_ft4x_max-size',
+        'res50': 'Detic_LCOCOI21k_CLIP_R5021k_640b32_4x_ft4x_max-size',
+        'res18': 'Detic_LCOCOI21k_CLIP_R18_640b32_4x_ft4x_max-size',
+    }
+
     @classmethod
     def from_args(cls, 
+            model_type: str = 'swin',
             enable_pubsub: bool = True,
             out_debug_img: bool = True,
             out_debug_segimg: bool = True,
@@ -46,9 +51,11 @@ class NodeConfig:
             device_name = 'cuda' if torch.cuda.is_available() else 'cpu'
 
         assert device_name in ['cpu', 'cuda']
+        assert model_type in NodeConfig.model_names
 
         pack_path = rospkg.RosPack().get_path('detic_ros')
 
+        model_name = NodeConfig.model_names[model_type]
         default_detic_config_path = os.path.join(
             pack_path, 'detic_configs',
             model_name + '.yaml')
@@ -73,6 +80,7 @@ class NodeConfig:
     def from_rosparam(cls):
 
         return cls.from_args(
+                rospy.get_param('~model_type', 'swin'),
                 rospy.get_param('~enable_pubsub', True),
                 rospy.get_param('~out_debug_img', True),
                 rospy.get_param('~out_debug_segimg', False),

--- a/node_script/node_config.py
+++ b/node_script/node_config.py
@@ -20,6 +20,7 @@ class NodeConfig:
     out_debug_img: bool
     out_debug_segimg: bool
     verbose: bool
+    use_jsk_msgs: bool
     vocabulary: str
     custom_vocabulary: str
     detic_config_path: str
@@ -41,6 +42,7 @@ class NodeConfig:
             out_debug_img: bool = True,
             out_debug_segimg: bool = True,
             verbose: bool = False,
+            use_jsk_msgs: bool = False,
             confidence_threshold: float = 0.5,
             device_name: str = 'auto',
             vocabulary: str = 'lvis',
@@ -69,6 +71,7 @@ class NodeConfig:
                 out_debug_img,
                 out_debug_segimg,
                 verbose,
+                use_jsk_msgs,
                 vocabulary,
                 custom_vocabulary,
                 default_detic_config_path,
@@ -85,6 +88,7 @@ class NodeConfig:
                 rospy.get_param('~out_debug_img', True),
                 rospy.get_param('~out_debug_segimg', False),
                 rospy.get_param('~verbose', True),
+                rospy.get_param('~use_jsk_msgs', False),
                 rospy.get_param('~confidence_threshold', 0.5),
                 rospy.get_param('~device', 'auto'),
                 rospy.get_param('~vocabulary', 'lvis'),

--- a/node_script/node_config.py
+++ b/node_script/node_config.py
@@ -13,6 +13,8 @@ from detectron2.config import get_cfg
 from centernet.config import add_centernet_config
 from detic.config import add_detic_config
 
+# model_name = 'Detic_LCOCOI21k_CLIP_SwinB_896b32_4x_ft4x_max-size'
+model_name = 'Detic_LCOCOI21k_CLIP_CXT21k_640b32_4x_ft4x_max-size'
 
 @dataclass
 class NodeConfig:
@@ -47,12 +49,12 @@ class NodeConfig:
         pack_path = rospkg.RosPack().get_path('detic_ros')
 
         default_detic_config_path = os.path.join(
-            pack_path, 'detic_configs', 
-            'Detic_LCOCOI21k_CLIP_SwinB_896b32_4x_ft4x_max-size.yaml')
+            pack_path, 'detic_configs',
+            model_name + '.yaml')
 
         default_model_weights_path = os.path.join(
             pack_path, 'models',
-            'Detic_LCOCOI21k_CLIP_SwinB_896b32_4x_ft4x_max-size.pth')
+            model_name + '.pth')
 
         return cls(
                 enable_pubsub,

--- a/node_script/node_config.py
+++ b/node_script/node_config.py
@@ -7,7 +7,7 @@ import rospkg
 import torch
 
 # Dirty but no way, because CenterNet2 is not package oriented
-sys.path.insert(0, os.path.join(sys.path[0], 'third_party/CenterNet2/projects/CenterNet2/'))
+sys.path.insert(0, os.path.join(sys.path[0], 'third_party/CenterNet2/'))
 
 from detectron2.config import get_cfg
 from centernet.config import add_centernet_config

--- a/node_script/node_config.py
+++ b/node_script/node_config.py
@@ -15,6 +15,7 @@ from detic.config import add_detic_config
 
 # model_name = 'Detic_LCOCOI21k_CLIP_SwinB_896b32_4x_ft4x_max-size'
 model_name = 'Detic_LCOCOI21k_CLIP_CXT21k_640b32_4x_ft4x_max-size'
+# model_name = 'Detic_LCOCOI21k_CLIP_R18_640b32_4x_ft4x_max-size'
 
 @dataclass
 class NodeConfig:

--- a/node_script/node_config.py
+++ b/node_script/node_config.py
@@ -18,7 +18,7 @@ from detic.config import add_detic_config
 class NodeConfig:
     enable_pubsub: bool
     out_debug_img: bool
-    out_debug_segimage: bool
+    out_debug_segimg: bool
     verbose: bool
     vocabulary: str
     custom_vocabulary: str
@@ -31,7 +31,7 @@ class NodeConfig:
     def from_args(cls, 
             enable_pubsub: bool = True,
             out_debug_img: bool = True,
-            out_debug_segimage: bool = True,
+            out_debug_segimg: bool = True,
             verbose: bool = False,
             confidence_threshold: float = 0.5,
             device_name: str = 'auto',
@@ -57,7 +57,7 @@ class NodeConfig:
         return cls(
                 enable_pubsub,
                 out_debug_img,
-                out_debug_segimage,
+                out_debug_segimg,
                 verbose,
                 vocabulary,
                 custom_vocabulary,
@@ -72,7 +72,7 @@ class NodeConfig:
         return cls.from_args(
                 rospy.get_param('~enable_pubsub', True),
                 rospy.get_param('~out_debug_img', True),
-                rospy.get_param('~out_debug_segimage', False),
+                rospy.get_param('~out_debug_segimg', False),
                 rospy.get_param('~verbose', True),
                 rospy.get_param('~confidence_threshold', 0.5),
                 rospy.get_param('~device', 'auto'),

--- a/node_script/wrapper.py
+++ b/node_script/wrapper.py
@@ -78,7 +78,7 @@ class DeticWrapper:
         sorted_index = np.argsort([-mask.sum() for mask in instances.pred_masks])
         for i in sorted_index:
             mask = instances.pred_masks[i]
-            # lable 0 is reserved for background label, so starting from 1
+            # label 0 is reserved for background label, so starting from 1
             data[mask] = (i + 1)
         self.data = data
         seg_img = self.bridge.cv2_to_imgmsg(data, encoding="32SC1")

--- a/node_script/wrapper.py
+++ b/node_script/wrapper.py
@@ -92,8 +92,8 @@ class DeticWrapper:
 
         # Get class and score arrays
         class_indexes = instances.pred_classes.tolist()
-        class_names_detected = ['background'] + [self.class_names[i] for i in class_indexes]
-        scores = [1.0] + instances.scores.tolist() # confidence with 1.0 about background detection
+        class_names_detected = [self.class_names[i] for i in class_indexes]
+        scores = instances.scores.tolist()
         return seg_img, class_names_detected, scores, visualized_output
 
     def get_debug_img(self, visualized_output: VisImage) -> Image:
@@ -122,7 +122,7 @@ class DeticWrapper:
 
     def get_label_array(self, detected_classes: List[str]) -> LabelArray:
         if self.idx is None:
-            labels = [Label(id=i, name=cls) for i,cls in enumerate(detected_classes)]
+            labels = [Label(id=i+1, name=cls) for i,cls in enumerate(detected_classes)]
         else:
             labels = [Label(id=self.idx[cls], name=cls) for i,cls in enumerate(detected_classes)]
         lab_arr = LabelArray(header=self.header,

--- a/node_script/wrapper.py
+++ b/node_script/wrapper.py
@@ -40,6 +40,13 @@ class DeticWrapper:
         self.class_names = self.predictor.metadata.get("thing_classes", None)
         self.header = None
         self.data = None
+        self.idx = None
+
+        if node_config.vocabulary == 'custom':
+            self.idx = {'background': 0}
+            for i,name in enumerate(node_config.custom_vocabulary.split(',')):
+                self.idx[name] = i+1
+
 
     @staticmethod
     def _adhoc_hack_metadata_path():
@@ -114,7 +121,10 @@ class DeticWrapper:
         return seg_info
 
     def get_label_array(self, detected_classes: List[str]) -> LabelArray:
-        labels = [Label(id=i, name=cls) for i,cls in enumerate(detected_classes)]
+        if self.idx is None:
+            labels = [Label(id=i, name=cls) for i,cls in enumerate(detected_classes)]
+        else:
+            labels = [Label(id=self.idx[cls], name=cls) for i,cls in enumerate(detected_classes)]
         lab_arr = LabelArray(header=self.header,
                              labels=labels)
         return lab_arr

--- a/node_script/wrapper.py
+++ b/node_script/wrapper.py
@@ -51,7 +51,10 @@ class DeticWrapper:
         if self.node_config.verbose:
             time_start = rospy.Time.now()
 
-        predictions, visualized_output = self.predictor.run_on_image(img)
+        if self.node_config.out_debug_img:
+            predictions, visualized_output = self.predictor.run_on_image(img)
+        else:
+            predictions = self.predictor.predictor(img)
         instances = predictions['instances'].to(torch.device("cpu"))
 
         if self.node_config.verbose:

--- a/node_script/wrapper.py
+++ b/node_script/wrapper.py
@@ -91,7 +91,7 @@ class DeticWrapper:
         self.seg_img.data = data.flatten().astype(np.uint8).tolist()
         # assert set(self.seg_img.data) == set(list(range(len(instances.pred_masks)+1)))
 
-        if self.node_config.out_debug_segimage:
+        if self.node_config.out_debug_segimg:
             debug_data = copy.deepcopy(data)
             human_friendly_scaling = 256//(len(instances.pred_masks) + 1)
             debug_data = debug_data * human_friendly_scaling

--- a/package.xml
+++ b/package.xml
@@ -11,6 +11,7 @@
   <build_depend>message_generation</build_depend>
   <exec_depend>message_runtime</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>jsk_recognition_msgs</exec_depend>
   <exec_depend>cv_bridge</exec_depend>
 
   <test_depend>rostest</test_depend>

--- a/prepare.sh
+++ b/prepare.sh
@@ -12,8 +12,12 @@ cd ..
 
 if [ ! -d "models" ]; then
     mkdir models
-    # wget https://dl.fbaipublicfiles.com/detic/Detic_LCOCOI21k_CLIP_SwinB_896b32_4x_ft4x_max-size.pth -O models/Detic_LCOCOI21k_CLIP_SwinB_896b32_4x_ft4x_max-size.pth
+    # SwinB model
+    wget https://dl.fbaipublicfiles.com/detic/Detic_LCOCOI21k_CLIP_SwinB_896b32_4x_ft4x_max-size.pth -O models/Detic_LCOCOI21k_CLIP_SwinB_896b32_4x_ft4x_max-size.pth
+    # ConvNet model
     wget https://dl.fbaipublicfiles.com/detic/Detic_LCOCOI21k_CLIP_CXT21k_640b32_4x_ft4x_max-size.pth -O models/Detic_LCOCOI21k_CLIP_CXT21k_640b32_4x_ft4x_max-size.pth
+    # Res18 model
+    wget https://dl.fbaipublicfiles.com/detic/Detic_LCOCOI21k_CLIP_R18_640b32_4x_ft4x_max-size.pth -O models/Detic_LCOCOI21k_CLIP_R18_640b32_4x_ft4x_max-size.pth
 fi
 
 pip3 install -r requirements.txt

--- a/prepare.sh
+++ b/prepare.sh
@@ -12,7 +12,8 @@ cd ..
 
 if [ ! -d "models" ]; then
     mkdir models
-    wget https://dl.fbaipublicfiles.com/detic/Detic_LCOCOI21k_CLIP_SwinB_896b32_4x_ft4x_max-size.pth -O models/Detic_LCOCOI21k_CLIP_SwinB_896b32_4x_ft4x_max-size.pth
+    # wget https://dl.fbaipublicfiles.com/detic/Detic_LCOCOI21k_CLIP_SwinB_896b32_4x_ft4x_max-size.pth -O models/Detic_LCOCOI21k_CLIP_SwinB_896b32_4x_ft4x_max-size.pth
+    wget https://dl.fbaipublicfiles.com/detic/Detic_LCOCOI21k_CLIP_CXT21k_640b32_4x_ft4x_max-size.pth -O models/Detic_LCOCOI21k_CLIP_CXT21k_640b32_4x_ft4x_max-size.pth
 fi
 
 pip3 install -r requirements.txt

--- a/prepare.sh
+++ b/prepare.sh
@@ -12,10 +12,15 @@ cd ..
 
 if [ ! -d "models" ]; then
     mkdir models
-    # SwinB model
+    # All real-time models
+    # https://github.com/facebookresearch/Detic/blob/main/docs/MODEL_ZOO.md#real-time-models
+
+    # Swin Transformer model
     wget https://dl.fbaipublicfiles.com/detic/Detic_LCOCOI21k_CLIP_SwinB_896b32_4x_ft4x_max-size.pth -O models/Detic_LCOCOI21k_CLIP_SwinB_896b32_4x_ft4x_max-size.pth
     # ConvNet model
     wget https://dl.fbaipublicfiles.com/detic/Detic_LCOCOI21k_CLIP_CXT21k_640b32_4x_ft4x_max-size.pth -O models/Detic_LCOCOI21k_CLIP_CXT21k_640b32_4x_ft4x_max-size.pth
+    # Res50 model
+    wget https://dl.fbaipublicfiles.com/detic/Detic_LCOCOI21k_CLIP_R5021k_640b32_4x_ft4x_max-size.pth -O models/Detic_LCOCOI21k_CLIP_R5021k_640b32_4x_ft4x_max-size.pth
     # Res18 model
     wget https://dl.fbaipublicfiles.com/detic/Detic_LCOCOI21k_CLIP_R18_640b32_4x_ft4x_max-size.pth -O models/Detic_LCOCOI21k_CLIP_R18_640b32_4x_ft4x_max-size.pth
 fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,13 +2,13 @@
 detectron2
 
 # Copied from Detic
-opencv-python
-timm
-dataclasses
-ftfy
-regex
-fasttext
-scikit-learn
-lvis
-nltk
+opencv-python==4.5.5.62
+timm==0.5.4
+dataclasses==0.6
+ftfy==6.0.3
+regex==2022.1.18
+fasttext==0.9.2
+scikit-learn==1.0.2
+lvis==0.5.3
+nltk==3.6.7
 git+https://github.com/openai/CLIP.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ ftfy==6.0.3
 regex==2022.1.18
 fasttext==0.9.2
 scikit-learn==1.0.2
+numpy==1.19
 lvis==0.5.3
 nltk==3.6.7
 git+https://github.com/openai/CLIP.git

--- a/test/test_detic_ros_node.py
+++ b/test/test_detic_ros_node.py
@@ -17,9 +17,11 @@ class TestNode(unittest.TestCase):
                 'msg1': None, 
                 'msg2': None, 
                 'msg3': None,
-                'msg4': None}
+                'msg4': None,
+                'msg5': None}
 
         def all_subscribed() -> bool:
+            rospy.logwarn("received: {}".format([not not v for v in cb_data.values()]))
             bool_list = [v is not None for v in cb_data.values()]
             return all(bool_list)
 
@@ -27,11 +29,13 @@ class TestNode(unittest.TestCase):
         def cb_debug_segimage(msg): cb_data['msg2'] = msg
         def cb_info(msg): cb_data['msg3'] = msg
         def cb_test_image(msg): cb_data['msg4'] = msg
+        def cb_test_image_filter(msg): cb_data['msg5'] = msg
 
         rospy.Subscriber('/docker/detic_segmentor/debug_image', Image, cb_debug_image)
         rospy.Subscriber('/docker/detic_segmentor/debug_segmentation_image', Image, cb_debug_segimage)
         rospy.Subscriber('/docker/detic_segmentor/segmentation_info', SegmentationInfo, cb_info)
         rospy.Subscriber('/test_out_image', Image, cb_test_image)
+        rospy.Subscriber('/test_out_image_filter', Image, cb_test_image_filter)
 
         time_out = 40
         for _ in range(time_out):

--- a/test/test_node.test
+++ b/test/test_node.test
@@ -10,7 +10,7 @@
 
   <include file="$(find detic_ros)/launch/sample.launch" >
     <arg name="out_debug_img" value="true" />
-    <arg name="out_debug_segimage" value="true" />
+    <arg name="out_debug_segimg" value="true" />
     <arg name="compressed" value="false" />
     <arg name="input_image" value="/image_publisher/image_raw" />
   </include>

--- a/test/test_node.test
+++ b/test/test_node.test
@@ -22,6 +22,14 @@
     <param name="out_image" value="/test_out_image" />
   </node>
 
+  <node pkg="detic_ros" type="masked_image_publisher.py" name="masked_image_publisher_filter"
+        args="bottle">
+    <param name="in_image" value="/image_publisher/image_raw" />
+    <param name="segmentation" value="/docker/detic_segmentor/segmentation_image" />
+    <param name="seginfo" value="/docker/detic_segmentor/segmentation_info" />
+    <param name="out_image" value="/test_out_image_filter" />
+  </node>
+
   <test pkg="detic_ros" type="test_detic_ros_node.py" test-name="test_detic_ros_node">
   </test>
 


### PR DESCRIPTION
- Update the detic submodule
- Add `model_type` option to select different real time models (https://github.com/facebookresearch/Detic/blob/main/docs/MODEL_ZOO.md#real-time-models)
- Add `use_jsk_msgs` option to publish the result as jsk_recognition_msgs types
- Add sample launch file of 3D object detection using the jsk_pcl_ros pipeline.
- Remove explicit `background` item from published topics for compatibility with jsk_recognition nodes.

With this I could get around 10Hz bounding box detection on the `res50`:
```
roslaunch detic_ros sample_detection.launch vocabulary:=custom custom_vocabulary:=cup,bottle,bottle_cap
```
![Screenshot from 2022-11-02 18-59-30](https://user-images.githubusercontent.com/20625381/199499891-c5b66103-0de1-4619-ad64-0d1571efba92.png)

