### PR TITLE
Update Dockerfile for sample_detection.launch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM nvidia/cuda:11.2.0-devel-ubuntu20.04
+ENV DEBIAN_FRONTEND=noninteractive
 RUN rm /etc/apt/sources.list.d/cuda.list
 
 RUN echo 'Etc/UTC' > /etc/timezone && \
@@ -46,12 +47,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-noetic-ros-core=1.5.0-1* \
     && rm -rf /var/lib/apt/lists/*
 
-# # install launch/sample_detection.launch dependencies
-# RUN apt-get install -y --no-install-recommends \
-#     ros-noetic-jsk-pcl-ros \
-#     ros-noetic-jsk-pcl-ros-utils \
-#     && rm -rf /var/lib/apt/lists/*
-
 # install bootstrap tools
 RUN apt-get update && apt-get install --no-install-recommends -y \
     build-essential \
@@ -68,6 +63,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN apt update && apt install python3-osrf-pycommon python3-catkin-tools -y
 RUN apt update && apt install ros-noetic-jsk-tools -y
 RUN apt update && apt install ros-noetic-image-transport-plugins -y
+
+# install launch/sample_detection.launch dependencies
+RUN apt update && apt install ros-noetic-jsk-pcl-ros ros-noetic-jsk-pcl-ros-utils -y
 
 WORKDIR /home/user
 


### PR DESCRIPTION
This PR solve https://github.com/HiroIshida/detic_ros/issues/34  

- Changed to install in the same way as other `ros-noetic-` packages.
- Avoid hang on keyboard country setting. https://stackoverflow.com/questions/63476497/docker-build-with-ubuntu-18-04-image-hangs-after-prompting-for-country-of-origin
- After consulting with @HiroIshida , I removed the comment out.

If we really want to comment in, do we need to change the wording in the README as well?