### PR TITLE
Build image_tranport_plugin from source

### DIFF
--- a/rosinstall.noetic
+++ b/rosinstall.noetic
@@ -1,0 +1,4 @@
+- git:
+    local-name: image_transport_plugins
+    uri: https://github.com/ros-perception/image_transport_plugins.git
+    version: noetic-devel


### PR DESCRIPTION
The depth compression nodes here causes the error, and because of this entire launched nodes do not function
https://github.com/HiroIshida/detic_ros/blob/e3596bd88c02f9f99f4dac2688741b6d886e2b57/launch/decompress_depth.launch#L6
[ERROR] [1668268511.903285160]: Unsupported image format: 32FC1; compressedDepth

Anyway, I fixed the error by building image_transport_plugins inside docker. But, I don't have time to find the cause of this.