### PR TITLE
Specify CvBridge encoding bgr8

### DIFF
--- a/node_script/wrapper.py
+++ b/node_script/wrapper.py
@@ -102,7 +102,7 @@ class DeticWrapper:
 
     def infer(self, msg: Image) -> InferenceRawResult:
         # Segmentation image, detected classes, detection scores, visualization image
-        img = _cv_bridge.imgmsg_to_cv2(msg, desired_encoding='passthrough')
+        img = _cv_bridge.imgmsg_to_cv2(msg, desired_encoding='bgr8')
 
         if self.node_config.verbose:
             time_start = rospy.Time.now()


### PR DESCRIPTION
The colors of the `debug_image` are inverted when the input image topic is not encoded in `bgr8`. I apologize for the lack of confirmation, but I suspect that the input to the Detic model is also inverted.  

This problem can be solved by specifying the encoding of the [CvBridge](http://wiki.ros.org/cv_bridge/Tutorials/ConvertingBetweenROSImagesAndOpenCVImagesPython ) conversion. This is [also done in jsk_recognition](https://github.com/jsk-ros-pkg/jsk_recognition/blob/975ef203577bb8ff5fa8f4a0b98464d36403baa7/jsk_perception/node_scripts/paper_finder.py#L260 ), which I used as a reference.   

#### image topic not in bgr8 encoding
```
$ rostopic echo /hsrb/head_rgbd_sensor/rgb/image_rect_color --noarr
header: 
  seq: 25135
  stamp: 
    secs: 1668335381
    nsecs: 431184046
  frame_id: "head_rgbd_sensor_rgb_frame"
height: 480
width: 640
encoding: "rgb8"
is_bigendian: 0
step: 1920
data: "<array type: uint8, length: 921600>"
---
```
|  before  |  after  |
| ---- | ---- |
|  ![Screenshot from 2022-11-13 19-09-23_crop](https://user-images.githubusercontent.com/38127823/201517212-0d1222da-c578-41ae-a448-91c7cd775cc0.png)  |  ![Screenshot from 2022-11-13 19-10-40_crop](https://user-images.githubusercontent.com/38127823/201517215-8e37be9b-ace2-40ea-979e-8c280d7f8cf6.png)  |

Comparison before and after change, the upper image is input image topic and the lower image is `debug_image`.   

#### image topic in bgr8 encoding
```
$ rostopic echo /kinect_head/rgb/image_color --noarr
header: 
  seq: 39033
  stamp: 
    secs: 1668335714
    nsecs: 387932439
  frame_id: "head_mount_kinect_rgb_optical_frame"
height: 480
width: 640
encoding: "bgr8"
is_bigendian: 0
step: 1920
data: "<array type: uint8, length: 921600>"
---
```
|  before  |  after  |
| ---- | ---- |
|  ![Screenshot from 2022-11-13 19-14-24](https://user-images.githubusercontent.com/38127823/201517375-c88c2ab9-c08a-4482-8fc0-3599ff5206b0.png)  |  ![Screenshot from 2022-11-13 19-13-29](https://user-images.githubusercontent.com/38127823/201517387-5a3c75af-cc1d-4a53-b9d5-862551461808.png)  |

Comparison before and after change, the upper image is `debug_image` and the lower image is input image topic.   
