### PR TITLE
Add arg to change target_frame_id in sample_detection.launch

### DIFF
--- a/launch/sample_detection.launch
+++ b/launch/sample_detection.launch
@@ -19,6 +19,7 @@
 
   <arg name="_input_image" default="/$(arg namespace)/decompressed_image"/>
   <arg name="_input_depth" default="/$(arg namespace)/decompressed_depth"/>
+  <arg name="target_frame_id" default="base_footprint" />
 
   <group ns='$(arg namespace)'>
 
@@ -81,12 +82,12 @@
       <remap from="~target" to="detic_euclidean_clustering/output"/>
       <remap from="~boxes" to="detic_segmentor/output/boxes"/>
       <remap from="~centroid_pose_array" to="detic_segmentor/output/centroid"/>
-      <rosparam>
+      <rosparam subst_value="true">
         align_boxes: true
         align_boxes_with_plane: false
         force_to_flip_z_axis: false
         use_pca: false
-        target_frame_id: base_footprint
+        target_frame_id: $(arg target_frame_id)
         approximate_sync: true
         queue_size: 100
       </rosparam>


### PR DESCRIPTION
This PR enables us to change `target_frame_id` param that is used in `ClusterPointIndicesDecomposer`.

`target_frame_id` is different among robots (eg. `base_footprint` in PR2 vs `base_link` in Fetch)