### PR TITLE
ci: fix broken ci

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -28,7 +28,9 @@ jobs:
           with:
               push: false
               tags: detic_ros:latest
-              build_args: INSTALL_JSK_PCL=false
+              build-args: # for testing purposes only
+                INSTALL_JSK_PCL=false
+                KEEP_LAUNCH_FILES=true
         - name: rostest
           run: |
               docker run --rm detic_ros:latest /bin/bash -i -c "source ~/.bashrc; rostest detic_ros test_node.test"

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -28,7 +28,7 @@ jobs:
           with:
               push: false
               tags: detic_ros:latest
-              build-args: # for testing purposes only
+              build-args: | # for testing purposes only
                 INSTALL_JSK_PCL=false
                 KEEP_LAUNCH_FILES=true
         - name: rostest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM nvidia/cuda:11.2.2-runtime-ubuntu20.04
+ARG KEEP_LAUNCH_FILES=false
 ENV DEBIAN_FRONTEND=noninteractive
 RUN rm /etc/apt/sources.list.d/cuda.list
 
@@ -98,7 +99,10 @@ RUN cd ~/detic_ws/src &&\
     cd ~/detic_ws && catkin init && catkin build
 
 # to avoid conflcit when mounting
-RUN rm -rf ~/detic_ws/src/detic_ros/launch
+RUN if [ "$KEEP_LAUNCH_FILES" = "false" ]; then \
+        rm -rf ~/detic_ws/src/detic_ros/launch; \
+    fi
+
 
 ########################################
 ########### ENV VARIABLE STUFF #########

--- a/mypy.ini
+++ b/mypy.ini
@@ -29,6 +29,8 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 [mypy-std_msgs.*]
 ignore_missing_imports = True
+[mypy-std_srvs.*]
+ignore_missing_imports = True
 [mypy-jsk_recognition_msgs.*]
 ignore_missing_imports = True
 [mypy-cv2]

--- a/node_script/node.py
+++ b/node_script/node.py
@@ -2,17 +2,23 @@
 from typing import Optional
 
 import rospy
+import torch
 from jsk_recognition_msgs.msg import LabelArray, VectorArray
 from node_config import NodeConfig
 from rospy import Publisher, Subscriber
 from sensor_msgs.msg import Image
-import torch
+from std_srvs.srv import Empty, EmptyRequest, EmptyResponse
 from wrapper import DeticWrapper
 
 from detic_ros.msg import SegmentationInfo
-from detic_ros.srv import DeticSeg, DeticSegRequest, DeticSegResponse
-from detic_ros.srv import CustomVocabulary, CustomVocabularyRequest, CustomVocabularyResponse
-from std_srvs.srv import Empty, EmptyRequest, EmptyResponse
+from detic_ros.srv import (
+    CustomVocabulary,
+    CustomVocabularyRequest,
+    CustomVocabularyResponse,
+    DeticSeg,
+    DeticSegRequest,
+    DeticSegResponse,
+)
 
 
 class DeticRosNode:
@@ -128,6 +134,7 @@ class DeticRosNode:
         self.detic_wrapper.predictor.set_defalt_vocabulary()
         res = EmptyResponse()
         return res
+
 
 if __name__ == '__main__':
     rospy.init_node('detic_node', anonymous=True)


### PR DESCRIPTION
For actual usage, we must remove launch file directory in the image when building time to avoid name conflict when lanuching. But for the rostest inside CI, we require these launch file for testing. So I added docker ARG to ON/OFF the keeping launch file behavior. default is false, thus removed but is set to true for testing (set in github action)