### PR TITLE
fix: lock predictor while updating it

### DIFF
--- a/node_script/node.py
+++ b/node_script/node.py
@@ -120,13 +120,15 @@ class DeticRosNode:
 
     def custom_vocab_srv(self, req: CustomVocabularyRequest) -> CustomVocabularyResponse:
         rospy.loginfo("Change vocabulary to {}".format(req.vocabulary))
-        self.detic_wrapper.predictor.change_vocabulary(",".join(req.vocabulary))
+        with self.detic_wrapper.predictor_lock:
+            self.detic_wrapper.predictor.change_vocabulary(",".join(req.vocabulary))
         res = CustomVocabularyResponse()
         return res
 
     def default_vocab_srv(self, req: EmptyRequest) -> EmptyResponse:
         rospy.loginfo("Change to default vocabulary")
-        self.detic_wrapper.predictor.set_defalt_vocabulary()
+        with self.detic_wrapper.predictor_lock:
+            self.detic_wrapper.predictor.set_defalt_vocabulary()
         res = EmptyResponse()
         return res
 

--- a/node_script/node.py
+++ b/node_script/node.py
@@ -120,15 +120,13 @@ class DeticRosNode:
 
     def custom_vocab_srv(self, req: CustomVocabularyRequest) -> CustomVocabularyResponse:
         rospy.loginfo("Change vocabulary to {}".format(req.vocabulary))
-        with self.detic_wrapper.predictor_lock:
-            self.detic_wrapper.predictor.change_vocabulary(",".join(req.vocabulary))
+        self.detic_wrapper.change_vocabulary(req.vocabulary)
         res = CustomVocabularyResponse()
         return res
 
     def default_vocab_srv(self, req: EmptyRequest) -> EmptyResponse:
         rospy.loginfo("Change to default vocabulary")
-        with self.detic_wrapper.predictor_lock:
-            self.detic_wrapper.predictor.set_defalt_vocabulary()
+        self.detic_wrapper.set_default_vocabulary()
         res = EmptyResponse()
         return res
 

--- a/src/detic_ros/wrapper.py
+++ b/src/detic_ros/wrapper.py
@@ -1,5 +1,6 @@
 import os
 from dataclasses import dataclass
+from threading import Lock
 from typing import List, Optional
 
 import detic
@@ -88,6 +89,7 @@ class DeticWrapper:
         dummy_args = self.DummyArgs(node_config.vocabulary, node_config.custom_vocabulary)
 
         self.predictor = VisualizationDemo(detectron_cfg, dummy_args)
+        self.predictor_lock = Lock()
         self.node_config = node_config
         self.class_names = self.predictor.metadata.get("thing_classes", None)
 
@@ -107,11 +109,12 @@ class DeticWrapper:
         if self.node_config.verbose:
             time_start = rospy.Time.now()
 
-        if self.node_config.out_debug_img:
-            predictions, visualized_output = self.predictor.run_on_image(img)
-        else:
-            predictions = self.predictor.predictor(img)
-            visualized_output = None
+        with self.predictor_lock:
+            if self.node_config.out_debug_img:
+                predictions, visualized_output = self.predictor.run_on_image(img)
+            else:
+                predictions = self.predictor.predictor(img)
+                visualized_output = None
         instances = predictions['instances'].to(torch.device("cpu"))
 
         if self.node_config.verbose:

--- a/src/detic_ros/wrapper.py
+++ b/src/detic_ros/wrapper.py
@@ -155,3 +155,11 @@ class DeticWrapper:
             msg.header,
             detected_classes_names)
         return result
+
+    def change_vocabulary(self, vocabulary: List[str]):
+        with self.predictor_lock:
+            self.predictor.change_vocabulary(",".join(vocabulary))
+
+    def set_default_vocabulary(self):
+        with self.predictor_lock:
+            self.predictor.set_defalt_vocabulary()  # TODO: fix typo => default


### PR DESCRIPTION
This PR guarantees that after vocabulary change service is called, the previous model with vocabulary is never be used. 
before: 

https://github.com/user-attachments/assets/c535ede9-8d6c-4965-af28-9b944241a2c7

after: 

https://github.com/user-attachments/assets/f0ac73df-a647-416d-a9df-8e11fb2c675b

