### PR TITLE
fix: rosdep update --include-eol-distros

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,7 @@ SHELL ["/bin/bash", "-c"]
 # Installing catkin package
 RUN mkdir -p ~/detic_ws/src
 RUN sudo apt install -y wget
-RUN sudo rosdep init && rosdep update && sudo apt update
+RUN sudo rosdep init && rosdep update --include-eol-distros && sudo apt update
 COPY --chown=user . /home/user/detic_ws/src/detic_ros
 RUN cd ~/detic_ws/src &&\
     source /opt/ros/noetic/setup.bash &&\

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ example of three dimensional pose recognition for cups, bottles, and bottle caps
 ``` shell
 cd <your catkin workspace>/src
 git clone git@github.com:HiroIshida/detic_ros.git
-rosdep update && rosdep install -iry .
+rosdep update --include-eol-distros && rosdep install -iry .
 cd ../
 catkin build
 ```

--- a/l4t/l4t.Dockerfile
+++ b/l4t/l4t.Dockerfile
@@ -19,7 +19,7 @@ RUN mkdir -p /catkin_ws/src/detic_ros
 COPY package.xml /catkin_ws/src/detic_ros
 RUN cd /catkin_ws/src/detic_ros &&\
     apt update &&\
-    rosdep update &&\
+    rosdep update --include-eol-distros &&\
     rosdep install --rosdistro=noetic -iqry --from-paths /catkin_ws/src &&\
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Problem
The docker build test in github action constantly fails after noetic's EOL, saying rosdep cannot find `catkin_virtualenv` s key, or more precisely
```
2025-06-03T02:31:29.3672814Z #28 2.277 ERROR: the following packages/stacks could not have their rosdep keys resolved
2025-06-03T02:31:29.3673957Z #28 2.277 to system dependencies:
2025-06-03T02:31:29.3674506Z #28 2.277 detic_ros: Cannot locate rosdep definition for [catkin_virtualenv]
2025-06-03T02:31:29.3675136Z #28 2.277 Continuing to install resolvable dependencies...
```

This almost surely because of the rosdep update skil's EOL distro. For example, if I run rosdep udpate locally, the  output is like
```
h-ishida@umejuice:~/.ros$ rosdep update
reading in sources list data from /etc/ros/rosdep/sources.list.d
Hit https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/osx-homebrew.yaml
Hit https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/base.yaml
Hit https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/python.yaml
Hit https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/ruby.yaml
Hit https://raw.githubusercontent.com/ros/rosdistro/master/releases/fuerte.yaml
Query rosdistro index https://raw.githubusercontent.com/ros/rosdistro/master/index-v4.yaml
Skip end-of-life distro "ardent"
Skip end-of-life distro "bouncy"
Skip end-of-life distro "crystal"
Skip end-of-life distro "dashing"
Skip end-of-life distro "eloquent"
Skip end-of-life distro "foxy"
Skip end-of-life distro "galactic"
Skip end-of-life distro "groovy"
Add distro "humble"
Skip end-of-life distro "hydro"
Skip end-of-life distro "indigo"
Skip end-of-life distro "iron"
Skip end-of-life distro "jade"
Add distro "jazzy"
Add distro "kilted"
Skip end-of-life distro "kinetic"
Skip end-of-life distro "lunar"
Skip end-of-life distro "melodic"
Skip end-of-life distro "noetic"
Add distro "rolling"
updated cache in /home/h-ishida/.ros/rosdep/sources.cache
```
where Noetic is skipped. And grepping `catkin_virtualenv` over db returns null:
```
h-ishida@umejuice:~/.ros$ rosdep db|grep catkin_virtual
h-ishida@umejuice:~/.ros$ 
```
(nothing found...)

## Solution(?)
rosdep udpate has option `--include-eol-distros`, to include the keys for noetic.
https://github.com/ros-infrastructure/rosdep/blob/5ec78c9f3d6be9484747ee4218ef17b6844a61bd/src/rosdep2/main.py#L375
```
h-ishida@umejuice:~/.ros$ rosdep update --include-eol-distros
reading in sources list data from /etc/ros/rosdep/sources.list.d
Hit https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/osx-homebrew.yaml
Hit https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/base.yaml
Hit https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/python.yaml
Hit https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/ruby.yaml
Hit https://raw.githubusercontent.com/ros/rosdistro/master/releases/fuerte.yaml
Query rosdistro index https://raw.githubusercontent.com/ros/rosdistro/master/index-v4.yaml
Add distro "ardent"
Add distro "bouncy"
Add distro "crystal"
Add distro "dashing"
Add distro "eloquent"
Add distro "foxy"
Add distro "galactic"
Add distro "groovy"
Add distro "humble"
Add distro "hydro"
Add distro "indigo"
Add distro "iron"
Add distro "jade"
Add distro "jazzy"
Add distro "kilted"
Add distro "kinetic"
Add distro "lunar"
Add distro "melodic"
Add distro "noetic"
Add distro "rolling"
updated cache in /home/h-ishida/.ros/rosdep/sources.cache
```

and now that the `catkin_virtualenv` key is included in the cache !
```
h-ishida@umejuice:~/.ros$ rosdep db|grep catkin_virtual
catkin_virtualenv -> ros-noetic-catkin-virtualenv
```