### PR TITLE
Fix ~detected_classes topic returning invalid class names when the vocabulary has been changed on runtime

### DIFF
--- a/src/detic_ros/wrapper.py
+++ b/src/detic_ros/wrapper.py
@@ -159,7 +159,9 @@ class DeticWrapper:
     def change_vocabulary(self, vocabulary: List[str]):
         with self.predictor_lock:
             self.predictor.change_vocabulary(",".join(vocabulary))
+            self.class_names = self.predictor.metadata.get("thing_classes", None)
 
     def set_default_vocabulary(self):
         with self.predictor_lock:
             self.predictor.set_defalt_vocabulary()  # TODO: fix typo => default
+            self.class_names = self.predictor.metadata.get("thing_classes", None)


### PR DESCRIPTION
`~detic_segmentor/detected_classes` topic returns invalid label name after the vocabulary has been changed on runtime.

For example, changing the vocabulary with the service call like

```
❯ rosservice call /docker/detic_segmentor/custom_vocabulary "vocabulary:
- 'bottle'
- 'can'"
```

.

Before the PR, `rostopic echo /docker/detic_segmentor/detected_classes` shows

```
header:
  seq: 154
  stamp:
    secs: 1750224124
    nsecs: 671259454
  frame_id: "hand_color_image_sensor"
labels:
  -
    id: 2
    name: "air_conditioner"
---
header:
  seq: 155
  stamp:
    secs: 1750224125
    nsecs:   5020066
  frame_id: "hand_color_image_sensor"
labels:
  -
    id: 2
    name: "air_conditioner"
---
header:
  seq: 156
  stamp:
    secs: 1750224125
    nsecs: 105631489
  frame_id: "hand_color_image_sensor"
labels:
  -
    id: 2
    name: "air_conditioner"
  -
    id: 1
    name: "aerosol_can"
---
header:
  seq: 157
  stamp:
    secs: 1750224125
    nsecs: 403846099
  frame_id: "hand_color_image_sensor"
labels:
  -
    id: 2
    name: "air_conditioner"
  -
    id: 1
    name: "aerosol_can"
---
```

which includes invalid label names.


After the PR, the one shows

```
---
header:
  seq: 27
  stamp:
    secs: 1750224189
    nsecs: 437882926
  frame_id: "hand_color_image_sensor"
labels:
  -
    id: 2
    name: "can"
  -
    id: 1
    name: "bottle"
```
