### PR TITLE
rossetmaster then rossetip

### DIFF
--- a/run_container.py
+++ b/run_container.py
@@ -61,7 +61,7 @@ if __name__ == "__main__":
                 /bin/bash -i -c \
                 "source ~/.bashrc; \
                 roscd detic_ros; \
-                rossetip; rossetmaster {host}; \
+                rossetmaster {host}; rossetip; \
                 roslaunch detic_ros {launch_file_name} {launch_args}"
                 """.format(
             tmp_launch_path=tmp_launch_path,


### PR DESCRIPTION
To set the ROS_IP on rossetip to be on the same subnet as the ROS MASTER, we must first run rossetmaster.